### PR TITLE
composed spec - parameter replacement

### DIFF
--- a/SpecificationPattern.Tests/ComposedSpecificationTests.cs
+++ b/SpecificationPattern.Tests/ComposedSpecificationTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Should;
+using Xunit;
+
+namespace SpecificationPattern.Tests {
+
+    public class ComposedSpecificationTests {
+
+        [Fact]
+        public void T1() {
+            var movie = new Movie("Some Movie", new DateTime(2010, 2, 1), MpaaRating.G, "Triller", 10);
+            var pg13Rating = new MpaaRatingAtMostSpecification(MpaaRating.PG13);
+            var goodMovie = new GoodMovieSpecification();
+            var composed = pg13Rating.And(goodMovie);
+
+            bool isSatisfiedBy = composed.IsSatisfiedBy(movie);
+
+            isSatisfiedBy.ShouldEqual(true);
+        }
+    }
+}

--- a/SpecificationPattern.Tests/SpecificationPattern.Tests.csproj
+++ b/SpecificationPattern.Tests/SpecificationPattern.Tests.csproj
@@ -60,6 +60,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ComposedSpecificationTests.cs" />
     <Compile Include="Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SpecificationPattern/ParameterReplacer.cs
+++ b/SpecificationPattern/ParameterReplacer.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq.Expressions;
+
+namespace SpecificationPattern {
+
+    internal class ParameterReplacer : ExpressionVisitor {
+
+        private readonly ParameterExpression _parameter;
+
+        protected override Expression VisitParameter(ParameterExpression node) 
+            => base.VisitParameter(_parameter);
+
+        internal ParameterReplacer(ParameterExpression parameter) {
+            _parameter = parameter;
+        }
+    }
+}

--- a/SpecificationPattern/SessionFactory.cs
+++ b/SpecificationPattern/SessionFactory.cs
@@ -14,7 +14,7 @@ namespace SpecificationPattern
 {
     public static class SessionFactory
     {
-        private const string ConnectionString = "Server=.;Database=SpecificationPattern;Trusted_Connection=true;";
+        private const string ConnectionString = @"Server=(localdb)\MSSQLLocalDB;Database=SpecificationPattern;Trusted_Connection=true;";
 
         private static readonly ISessionFactory _factory;
 

--- a/SpecificationPattern/SessionFactory.cs
+++ b/SpecificationPattern/SessionFactory.cs
@@ -14,7 +14,7 @@ namespace SpecificationPattern
 {
     public static class SessionFactory
     {
-        private const string ConnectionString = @"Server=(localdb)\MSSQLLocalDB;Database=SpecificationPattern;Trusted_Connection=true;";
+        private const string ConnectionString = @"Server=.;Database=SpecificationPattern;Trusted_Connection=true;";
 
         private static readonly ISessionFactory _factory;
 

--- a/SpecificationPattern/SpecificationPattern.csproj
+++ b/SpecificationPattern/SpecificationPattern.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Movie.cs" />
     <Compile Include="MovieMap.cs" />
     <Compile Include="MovieRepository.cs" />
+    <Compile Include="ParameterReplacer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SessionFactory.cs" />
     <Compile Include="Specifications.cs" />

--- a/SpecificationPattern/Specifications.cs
+++ b/SpecificationPattern/Specifications.cs
@@ -1,81 +1,76 @@
 ﻿using System;
-using System.Linq;
 using System.Linq.Expressions;
 
 
-namespace SpecificationPattern
-{
-    public abstract class Specification<T>
-    {
+namespace SpecificationPattern {
+
+    public abstract class Specification<T> {
+
         public abstract Expression<Func<T, bool>> ToExpression();
 
 
-        public bool IsSatisfiedBy(T entity)
-        {
+        public bool IsSatisfiedBy(T entity) {
             Func<T, bool> predicate = ToExpression().Compile();
             return predicate(entity);
         }
 
 
-        public Specification<T> And(Specification<T> specification)
-        {
+        public Specification<T> And(Specification<T> specification) {
             return new AndSpecification<T>(this, specification);
         }
 
 
-        public Specification<T> Or(Specification<T> specification)
-        {
+        public Specification<T> Or(Specification<T> specification) {
             return new OrSpecification<T>(this, specification);
         }
     }
 
 
-    public class AndSpecification<T> : Specification<T>
-    {
+    public class AndSpecification<T> : Specification<T> {
         private readonly Specification<T> _left;
         private readonly Specification<T> _right;
 
 
-        public AndSpecification(Specification<T> left, Specification<T> right)
-        {
+        public AndSpecification(Specification<T> left, Specification<T> right) {
             _right = right;
             _left = left;
         }
 
 
-        public override Expression<Func<T, bool>> ToExpression()
-        {
+        public override Expression<Func<T, bool>> ToExpression() {
             Expression<Func<T, bool>> leftExpression = _left.ToExpression();
             Expression<Func<T, bool>> rightExpression = _right.ToExpression();
 
-            BinaryExpression andExpression = Expression.AndAlso(leftExpression.Body, rightExpression.Body);
+            var paramExpr = Expression.Parameter(typeof(T));
+            var exprBody = Expression.AndAlso(leftExpression.Body, rightExpression.Body);
+            exprBody = (BinaryExpression)new ParameterReplacer(paramExpr).Visit(exprBody);
+            var finalExpr = Expression.Lambda<Func<T, bool>>(exprBody, paramExpr);
 
-            return Expression.Lambda<Func<T, bool>>(andExpression, leftExpression.Parameters.Single());
+            return finalExpr;
         }
     }
 
 
-    public class OrSpecification<T> : Specification<T>
-    {
+    public class OrSpecification<T> : Specification<T> {
         private readonly Specification<T> _left;
         private readonly Specification<T> _right;
 
 
-        public OrSpecification(Specification<T> left, Specification<T> right)
-        {
+        public OrSpecification(Specification<T> left, Specification<T> right) {
             _right = right;
             _left = left;
         }
 
 
-        public override Expression<Func<T, bool>> ToExpression()
-        {
-            Expression<Func<T, bool>> leftExpression = _left.ToExpression();
-            Expression<Func<T, bool>> rightExpression = _right.ToExpression();
+        public override Expression<Func<T, bool>> ToExpression() {
+            var leftExpression = _left.ToExpression();
+            var rightExpression = _right.ToExpression();
+            var paramExpr = Expression.Parameter(typeof(T));
+            var exprBody = Expression.OrElse(leftExpression.Body, rightExpression.Body);
+            exprBody = (BinaryExpression)new ParameterReplacer(paramExpr).Visit(exprBody);
+            var finalExpr = Expression.Lambda<Func<T, bool>>(exprBody, paramExpr);
 
-            BinaryExpression andExpression = Expression.OrElse(leftExpression.Body, rightExpression.Body);
-
-            return Expression.Lambda<Func<T, bool>>(andExpression, leftExpression.Parameters.Single());
+            return finalExpr;
         }
     }
 }


### PR DESCRIPTION
Fixes invalid op exception when composing specs. Includes test that fails under old code but now passes. 

Parameter replacement fix from https://stackoverflow.com/a/6736589

I really like this idea. Thanks for this. Keep those Pluralsights coming!