### PR TITLE
Fixed parameter replacer for expressions containing references to children

### DIFF
--- a/SpecificationPattern/ParameterReplacer.cs
+++ b/SpecificationPattern/ParameterReplacer.cs
@@ -6,8 +6,13 @@ namespace SpecificationPattern {
 
         private readonly ParameterExpression _parameter;
 
-        protected override Expression VisitParameter(ParameterExpression node) 
-            => base.VisitParameter(_parameter);
+        protected override Expression VisitParameter(ParameterExpression node) {
+            if (_parameter.Type != node.Type) {
+                return node;
+            }
+
+            return base.VisitParameter(_parameter);
+        }
 
         internal ParameterReplacer(ParameterExpression parameter) {
             _parameter = parameter;


### PR DESCRIPTION
Parameter replacer was not working when working with expressions on root and it's children.

i.e if our expression contained some expression like that: return root.Children.Any(child => child.Property == "123"), current implementation of parameter replacer would replace the child paramer with root parameter leading to exception mentioned by other user in issue 4.
Please have in mind this error occurs only when the expression is combined using And/Or/Not specifications.